### PR TITLE
manually create v1.6.21 to fix cdn for extended plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # igm-public-assets
-Public assets for the Interactive Geo Maps project
+
+Public assets for the [https://interactivegeomaps.com/](https://interactivegeomaps.com/) served behind a CDN from [https://extended.interactivegeomaps.com/](https://extended.interactivegeomaps.com/)


### PR DESCRIPTION
Manually create v1.6.21 to fix cdn for extended plugin. 
This was erroneously skipped in CI from main plugin.